### PR TITLE
修复编译错误、添加cors支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     },
     "dependencies": {
         "chalk": "4",
-        "chalk-template": "^1.1.0",
         "clipcc-extension": "^0.2.0"
     }
 }

--- a/src/native/plugins.ts
+++ b/src/native/plugins.ts
@@ -1,49 +1,78 @@
-import { Linter } from 'eslint';
-import fs from 'fs';
-import { ExtendWebpackConfig, NativePlugin } from './structs/plugin';
-import path from 'path';
-import { Configuration } from 'webpack';
-import chalkTemplate from 'chalk-template';
+import { Linter } from "eslint";
+import fs from "fs";
+import { ExtendWebpackConfig, NativePlugin } from "./structs/plugin";
+import path from "path";
+import { Configuration } from "webpack";
+import chalk from "chalk";
 
 export function load() {
-    console.log(`Mode: ${process.env.NODE_ENV === 'production' ? 'production' : 'development'}`);
-    const disablePlugins = JSON.parse(fs.readFileSync(path.join(__dirname, '../../plugins/disable.json'), 'utf-8')) as Record<'platform' | 'folder', string[]>;
-    const webpack: Record<string, (config: ExtendWebpackConfig) => Configuration> = {};
-    const eslint: Linter.Config[] = [];
-    const pluginsDir = path.join(__dirname, '../../plugins');
-    const pluginFolders = fs.readdirSync(pluginsDir)
-        .filter(file => fs.statSync(path.join(pluginsDir, file)).isDirectory());
-    const pluginIds: string[] = [];
-    function pad(id: string) {
-        return id.padEnd(Math.max(...pluginIds.map(id => id.length)), ' ');
+  console.log(
+    `Mode: ${
+      process.env.NODE_ENV === "production" ? "production" : "development"
+    }`
+  );
+  const disablePlugins = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "../../plugins/disable.json"), "utf-8")
+  ) as Record<"platform" | "folder", string[]>;
+  const webpack: Record<
+    string,
+    (config: ExtendWebpackConfig) => Configuration
+  > = {};
+  const eslint: Linter.Config[] = [];
+  const pluginsDir = path.join(__dirname, "../../plugins");
+  const pluginFolders = fs
+    .readdirSync(pluginsDir)
+    .filter((file) => fs.statSync(path.join(pluginsDir, file)).isDirectory());
+  const pluginIds: string[] = [];
+  function pad(id: string) {
+    return id.padEnd(Math.max(...pluginIds.map((id) => id.length)), " ");
+  }
+  for (const folder of pluginFolders) {
+    pluginIds.push(folder);
+  }
+  for (const folder of pluginFolders) {
+    const currentNativeId = folder;
+    if (disablePlugins.folder.includes(currentNativeId)) {
+      console.log(
+        `${chalk.gray(pad(currentNativeId))} | ${chalk.red("DISABLED")}`
+      );
+      continue;
     }
-    for (const folder of pluginFolders) {
-        pluginIds.push(folder);
-    }
-    for (const folder of pluginFolders) {
-        const currentNativeId = folder;
-        if (disablePlugins.folder.includes(currentNativeId)) {
-            console.log(chalkTemplate`{gray ${pad(currentNativeId)}} | {red DISABLED}`);
-            continue;
+    try {
+      const nativePath = path.resolve(
+        "dist/native/plugins",
+        folder,
+        "native.js"
+      );
+      if (fs.existsSync(nativePath)) {
+        const {
+          default: plugin,
+        }: { default: NativePlugin } = require(nativePath);
+        if (disablePlugins.platform.includes(plugin.platform)) {
+          console.log(
+            `${chalk.gray(pad(plugin.platform))} | ${chalk.red("DISABLED")}`
+          );
+          continue;
         }
-        try {
-            const nativePath = path.resolve('dist/native/plugins', folder, 'native.js');
-            if (fs.existsSync(nativePath)) {
-                const { default: plugin }: { default: NativePlugin } = require(nativePath);
-                if (disablePlugins.platform.includes(plugin.platform)) {
-                    console.log(chalkTemplate`{gray ${pad(plugin.platform)}} | {red DISABLED}`);
-                    continue;
-                }
-                webpack[currentNativeId] = plugin.configureWebpack?.call(plugin) ?? (() => ({}));
-                eslint.push(...(plugin.configureESLint?.call(plugin) ?? []));
-                console.log(chalkTemplate`{gray ${pad(currentNativeId)}} | {green loaded successfully}: {cyan ${plugin.platform}}.`);
-            } else {
-                webpack[currentNativeId] = () => ({});
-                console.warn(chalkTemplate`{gray ${pad(currentNativeId)}} | {yellow not found native module}.`);
-            }
-        } catch (err) {
-            console.error(chalkTemplate`{gray ${pad(currentNativeId)}} | {red ${err}}`);
-        }
+        webpack[currentNativeId] =
+          plugin.configureWebpack?.call(plugin) ?? (() => ({}));
+        eslint.push(...(plugin.configureESLint?.call(plugin) ?? []));
+        console.log(
+          `${chalk.gray(pad(currentNativeId))} | ${chalk.green(
+            "loaded successfully"
+          )}: ${chalk.cyan(plugin.platform)}.`
+        );
+      } else {
+        webpack[currentNativeId] = () => ({});
+        console.warn(
+          `${chalk.gray(pad(currentNativeId))} | ${chalk.yellow(
+            "not found native module"
+          )}.`
+        );
+      }
+    } catch (err) {
+      console.error(`${chalk.gray(pad(currentNativeId))} | ${chalk.red(err)}`);
     }
-    return { webpack, eslint };
+  }
+  return { webpack, eslint };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,52 +1,29 @@
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "module": "commonjs",
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "skipLibCheck": true,
-        "experimentalDecorators": true,
-        "moduleResolution": "node",
-        "allowJs": true,
-        "checkJs": true,
-        "isolatedModules": true,
-        "resolveJsonModule": true,
-        "typeRoots": [
-            "node_modules/@types",
-            "node_modules/@turbowarp/types"
-        ],
-        "types": [
-            "webpack-env",
-            "node",
-            "index.d.ts"
-        ],
-        "baseUrl": ".",
-        "outDir": "dist/native",
-        "paths": {
-            "fs-context": [
-                "src/fs-context/index"
-            ],
-            "package.json": [
-                "package.json"
-            ],
-            "fs-context/*": [
-                "src/fs-context/*"
-            ],
-            "@/*": [
-                "src/extension/*"
-            ],
-            "@sample/*": [
-                "src/fs-context/samples/*"
-            ],
-            "@plugin/*": [
-                "plugins/*"
-            ]
-        }
-    },
-    "include": [
-        "src/**/*.ts",
-        "plugins/**/*.ts",
-        "plugins/disable.json"
-    ]
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "typeRoots": ["node_modules/@types", "node_modules/@turbowarp/types"],
+    "types": ["webpack-env", "node", "index.d.ts"],
+    "baseUrl": ".",
+    "outDir": "dist/native",
+    "paths": {
+      "fs-context": ["src/fs-context/index"],
+      "package.json": ["package.json"],
+      "fs-context/*": ["src/fs-context/*"],
+      "@/*": ["src/extension/*"],
+      "@sample/*": ["src/fs-context/samples/*"],
+      "@plugin/*": ["plugins/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "plugins/**/*.ts", "plugins/disable.json"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,78 +1,90 @@
-const path = require('path');
-const webpack = require('webpack');
+const path = require("path");
+const webpack = require("webpack");
 
-const Webpackbar = require('webpackbar');
+const Webpackbar = require("webpackbar");
 
-const tsconfigJson = require('./tsconfig.json');
-const packageJson = require('./package.json');
-const { merge } = require('webpack-merge');
+const tsconfigJson = require("./tsconfig.json");
+const packageJson = require("./package.json");
+const { merge } = require("webpack-merge");
 
 module.exports = () => {
-    const { webpack: webpackConfig } = require('./dist/native/src/native/plugins').load();
-    return packageJson.extension.platform.map((platform) => {
-        const filename = `[${platform}]${packageJson.extension.id}@${packageJson.extension.version}.js`;
-        const base = {
-            name: platform,
-            entry: 'fs-context/entry.ts',
-            resolve: {
-                extensions: ['.js', '.ts'],
-                alias: Object.fromEntries(
-                    Object.entries(tsconfigJson.compilerOptions.paths)
-                        .map(([key, value]) => [key.replace('/*', ''), path.resolve(__dirname, value[0].replace('/*', ''))])
-                )
-            },
-            output: {
-                path: path.resolve(__dirname, 'dist'),
-                filename
-            },
-            module: {
-                rules: [
-                    {
-                        test: /\.ts$/i,
-                        use: 'ts-loader',
-                        exclude: /node_modules/
-                    }
-                ]
-            },
-            plugins: [
-                new Webpackbar({
-                    name: packageJson.extension.name.toUpperCase(),
-                    color: 'green'
-                }),
-                new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
-                new webpack.DefinePlugin({
-                    fsContext: JSON.stringify({
-                        platform,
-                        developing: process.env.NODE_ENV === 'development',
-                        extension: packageJson.extension
-                    })
-                })
-            ],
-            /**
-             * @type {import('webpack-dev-server').Configuration}
-             */
-            devServer: {
-                port: 7777,
-                setupExitSignals: false,
-                webSocketServer: false,
-                client: {
-                    logging: 'none'
-                },
-                setupMiddlewares(mw, server) {
-                    server.app.get('/', (_, res) => {
-                        res.redirect(`/${filename}`);
-                    });
-                    return mw;
-                },
-                allowedHosts: 'all'
-            },
-            mode: process.env.NODE_ENV,
-            stats: 'errors-warnings'
-        };
-        return merge(base, webpackConfig[platform]({ filename, base }) ?? {}, {
-            plugins: [
-                //pass
+  const { webpack: webpackConfig } =
+    require("./dist/native/src/native/plugins").load();
+  return packageJson.extension.platform.map((platform) => {
+    const filename = `[${platform}]${packageJson.extension.id}@${packageJson.extension.version}.js`;
+    const base = {
+      name: platform,
+      entry: "fs-context/entry.ts",
+      resolve: {
+        extensions: [".js", ".ts"],
+        alias: Object.fromEntries(
+          Object.entries(tsconfigJson.compilerOptions.paths).map(
+            ([key, value]) => [
+              key.replace("/*", ""),
+              path.resolve(__dirname, value[0].replace("/*", "")),
             ]
-        });
-    })
+          )
+        ),
+      },
+      output: {
+        path: path.resolve(__dirname, "dist"),
+        filename,
+      },
+      module: {
+        rules: [
+          {
+            test: /\.ts$/i,
+            use: "ts-loader",
+            exclude: /node_modules/,
+          },
+        ],
+      },
+      plugins: [
+        new Webpackbar({
+          name: packageJson.extension.name.toUpperCase(),
+          color: "green",
+        }),
+        new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+        new webpack.DefinePlugin({
+          fsContext: JSON.stringify({
+            platform,
+            developing: process.env.NODE_ENV === "development",
+            extension: packageJson.extension,
+          }),
+        }),
+      ],
+      /**
+       * @type {import('webpack-dev-server').Configuration}
+       */
+      devServer: {
+        port: 7777,
+        setupExitSignals: false,
+        webSocketServer: false,
+        client: {
+          logging: "none",
+        },
+        setupMiddlewares(mw, server) {
+          server.app.get("/", (_, res) => {
+            res.redirect(`/${filename}`);
+          });
+          return mw;
+        },
+        allowedHosts: "all",
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods":
+            "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+          "Access-Control-Allow-Headers":
+            "X-Requested-With, content-type, Authorization",
+        },
+      },
+      mode: process.env.NODE_ENV,
+      stats: "errors-warnings",
+    };
+    return merge(base, webpackConfig[platform]({ filename, base }) ?? {}, {
+      plugins: [
+        //pass
+      ],
+    });
+  });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,13 +1107,6 @@ caniuse-lite@^1.0.30001726:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001733.tgz#918405ed6647a62840fb328832cf5a03f986974b"
   integrity sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==
 
-chalk-template@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.0.tgz#ffc55db6dd745e9394b85327c8ac8466edb7a7b1"
-  integrity sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==
-  dependencies:
-    chalk "^5.2.0"
-
 chalk@4, chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1130,11 +1123,6 @@ chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^5.2.0:
-  version "5.5.0"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz#67ada1df5ca809dc84c9b819d76418ddcf128428"
-  integrity sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==
 
 chokidar@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
# CORS 支持
在 devServer 配置中添加了 CORS headers

# 修复编译问题
问题原因：

chalk-template 1.1.0 版本是一个纯 ES 模块，不能在 CommonJS 环境中使用 require() 导入
项目的 TypeScript 配置将模块编译为 CommonJS 格式 ("module": "commonjs")
这导致了 ERR_REQUIRE_ESM 错误
解决方案：
我将 chalk-template 替换为 chalk，具体修改如下：

移除了 ES 模块导入：
``` 
// 删除
import chalkTemplate from 'chalk-template';
```
```
// 添加
import chalk from 'chalk';
```
替换了模板字符串调用：
```
// 从
chalkTemplate`{gray ${pad(currentNativeId)}} | {red DISABLED}`

// 改为
`${chalk.gray(pad(currentNativeId))} | ${chalk.red('DISABLED')}`
```
保持了相同的颜色效果.
# Tip
由于使用了代码自动格式化插件，Diff可能不易阅读，很抱歉对开发者带来了麻烦